### PR TITLE
Migrate tools dev version required for Drush 1 (temporary)

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@ Composer meta-package for base contrib modules to use for JFE Drupal sites
 
 ## Version History
 
+1.0.13 - Migrate tools dev version works with drush 10.6.1, stable version does not currently (https://www.drupal.org/project/migrate_tools/issues/3212876)
+
 1.0.12 - Prefer stable true
 
 1.0.11 - Add Menu Admin per Role

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
       "drupal/menu_admin_per_menu": "^1.3",
       "drupal/metatag": "^1.16",
       "drupal/migrate_plus": "^5.1",
-      "drupal/migrate_tools": "^5.0",
+      "drupal/migrate_tools": "5.x-dev@dev",
       "drupal/moderation_sidebar": "^1.4",
       "drupal/node_view_permissions": "^1.4",
       "drupal/paragraphs": "^1.12",
@@ -67,5 +67,5 @@
       "drupal/weight": "^3.3",
       "kint-php/kint": "^3.3"
     },
-    "version": "1.0.12"
+    "version": "1.0.13"
 }


### PR DESCRIPTION
@johnperryjfe - I need to test this today, but letting you know about this via the message. If this doesn't work, I'll revert.