### PR TITLE
Fix auto entity label beta version

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@ Composer meta-package for base contrib modules to use for JFE Drupal sites
 
 ## Version History
 
+1.0.14 - Fix auto entity label beta version
+
 1.0.13 - Add Pantheon Advanced Page Cache
 
 1.0.12 - Prefer stable true

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
       "drupal/addtoany": "^1.15",
       "drupal/admin_toolbar": "^3.0",
       "drupal/allowed_formats": "^1.3",
-      "drupal/auto_entitylabel": "^3.0@beta",
+      "drupal/auto_entitylabel": "3.0-beta4",
       "drupal/better_exposed_filters": "^5.0@beta",
       "drupal/block_class": "^1.3",
       "drupal/block_field": "^1.0@RC",
@@ -66,5 +66,5 @@
       "drupal/weight": "^3.3",
       "kint-php/kint": "^3.3"
     },
-    "version": "1.0.13"
+    "version": "1.0.14"
 }


### PR DESCRIPTION
Apparently to install with min-stability to stable, beta packages need to specify the specific version.
@johnperryjfe  - tagging so you can see...